### PR TITLE
Refactor Fine table to act as an immutable financial ledger

### DIFF
--- a/common/fine.go
+++ b/common/fine.go
@@ -8,11 +8,22 @@ import (
 
 type Fine struct {
 	gorm.Model
-	ID          int `gorm:"primaryKey"`
-	UserID      int
-	UserRef     User
-	LoanID      int
-	LoanRef     Loan
-	Amount      float32
-	PaymentDate time.Time
+	ID             int `gorm:"primaryKey"`
+	UserID         int
+	UserRef        User
+	LoanID         int
+	LoanRef        Loan
+	AmountAssessed float32
+	AmountPaid     float32
+	Status         FineStatus
+	LastPayment    time.Time
 }
+
+type FineStatus int
+
+const (
+	FineStatusUnpaid FineStatus = iota
+	FineStatusPartial
+	FineStatusPaid
+	FineStatusWaived
+)

--- a/common/fine.go
+++ b/common/fine.go
@@ -6,24 +6,44 @@ import (
 	"gorm.io/gorm"
 )
 
+// A fine that must be paid before the user can check out more books.
+// A fine can be issued for any reason, including late, lost, or damaged.
 type Fine struct {
 	gorm.Model
-	ID             int `gorm:"primaryKey"`
-	UserID         int
-	UserRef        User
-	LoanID         int
-	LoanRef        Loan
-	AmountAssessed float32
-	AmountPaid     float32
-	Status         FineStatus
-	LastPayment    time.Time
+	ID      int `gorm:"primaryKey"`
+	UserID  int
+	UserRef User
+	LoanID  int
+	LoanRef Loan
+
+	IssueReason     FineReasonFlag
+	IssueDate       time.Time
+	AmountIssued    float32
+	AmountRemaining float32 // How much is remaining, recalculated after every transaction
+
+	AmountWaived  float32 // Any discounts provided by a librarian
+	WaivedReasion string
+	WaivedBy      string
 }
 
-type FineStatus int
+// Transactions resolve the oldest fines first
+/* TO-DO: Figure out how to link transactions to specific fines
+ *        - Do we split one transaction into its components?
+ *        - Do we not care?
+ *        - Do we include a list of Fine IDs?
+ */
+type Transaction struct {
+	gorm.Model
+	UserID     int
+	UserRef    User
+	AmountPaid float32
+	Date       time.Time
+}
+
+type FineReasonFlag int
 
 const (
-	FineStatusUnpaid FineStatus = iota
-	FineStatusPartial
-	FineStatusPaid
-	FineStatusWaived
+	FineReasonLate FineReasonFlag = iota
+	FineReasonLost
+	FineReasonDamaged
 )


### PR DESCRIPTION
## Context & Motivation
Following our discussion regarding the `Fine` table, I agree that treating actively accruing fines as stored data (using background tasks to constantly update amounts) is demanding, redundant, and an anti-pattern. Accruing fines should absolutely be calculated dynamically by the backend on-demand. 

However, rather than removing the table or moving its fields, this PR refactors the `Fine` table into a **financial ledger**. 

## Reasoning
A dedicated ledger table is critical for the following reasons:
1. **Immutable Financial Records:** Fines are financial records. Say the library adjusts it's fine rate from $2/wk to $3/wk, you can't retroactively apply that amount to a balance. Once a fine is finalized, it's immutable. Also having unique IDs linked to the movement of money is critical in an audit.
2. **Partial Payments:** The previous table could not track partial payments. A ledger allows us to easily compute and track remaining balances.
3. **Manual Adjustments:** Librarians frequently waive or adjust fines (e.g., was in the hospital). We need standalone records to track these specific admin overrides.
4. **Alternative Fee Types:** Books that are lost are typically assessed a flat replacement fee rather than a continuing accrued fine. A dedicated ledger handles these varied fee types much better than merging fields into other tables.

## Changes Made
Shifted the schema from tracking *current accrued amount* to tracking *immutable debts and payments*:
- **Removed** the original `Amount` and `PaymentDate` fields.
- **Added `AmountAssessed`**: Stored at the time of payment or overriden by an admin.
- **Added `AmountPaid`**: Provides support for partial payments.
- **Added `Status`**: Uses a new `FineStatus` enum (`Unpaid`, `Partial`, `Paid`, `Waived`) to clearly track the lifecycle of the fine and allow the system to assess further modifications. 
- **Retained `LoanID`**: Explicitly links debts to the exact loan/borrowing event, which is vital for disputes.